### PR TITLE
Add installation instructions using use-package + :vc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,90 @@
 # eglot-booster: Boost eglot using lsp-booster
 
-The [emacs-lsp-booster](https://github.com/blahgeek/emacs-lsp-booster) project provides a rust-based wrapper program which substantially speeds up emacs' interactions with lsp servers.   This small package enables [eglot](https://github.com/joaotavora/eglot) to use it.
+The [emacs-lsp-booster](https://github.com/blahgeek/emacs-lsp-booster) project provides a Rust-based wrapper program which substantially speeds up Emacs' interactions with LSP servers. This small package enables [eglot](https://github.com/joaotavora/eglot) to use it.
 
 ## Install/Usage
 
-Install directly from this repo via `M-x package-vc-install` (pasting in this URL), or using, e.g. `straight`.  Then, in your init, simply 
+Install directly from this repo via `M-x package-vc-install` (pasting in this URL), or using `straight`. Then, in your init:
 
 ```elisp
 (use-package eglot-booster
-	:after eglot
-	:config	(eglot-booster-mode))
-```
+  :after eglot
+  :config
+  (eglot-booster-mode))
+````
 
-If you're using straight, use this instead:
+### Using `straight`:
 
 ```elisp
 (use-package eglot-booster
-	:straight ( eglot-booster :type git :host nil :repo "https://github.com/jdtsmith/eglot-booster")
-	:after eglot
-	:config (eglot-booster-mode))
+  :straight (eglot-booster
+             :type git
+             :host nil
+             :repo "https://github.com/jdtsmith/eglot-booster")
+  :after eglot
+  :config
+  (eglot-booster-mode))
 ```
 
-Then just use eglot as normal.  You should notice no differences other than speedier performance and less I/O blocking.
+### Using `use-package` with the built-in `:vc`
 
-To verify that the wrapper is functioning, `M-x eglot-events-buffer` and look at the beginning for `emacs_lsp_booster::app` notices.  If you'd like to avoid boosting remote servers (those run over TRAMP), set `eglot-booster-no-remote-boost` to `t`. 
+```elisp
+(use-package eglot-booster
+  :vc (:url "https://github.com/jdtsmith/eglot-booster")
+  :after eglot
+  :config
+  (eglot-booster-mode))
+```
+
+Then just use Eglot as normal. You should notice no differences other than speedier performance and less I/O blocking.
+
+To verify that the wrapper is functioning, run:
+
+```
+M-x eglot-events-buffer
+```
+
+and look near the beginning for `emacs_lsp_booster::app` notices. If you'd like to avoid boosting remote servers (those run over TRAMP), set:
+
+```elisp
+(setq eglot-booster-no-remote-boost t)
+```
 
 > [!IMPORTANT]
-> At present only local or remote (tramp-based) lsp server programs which communicate by standard input/output can be wrapped, not lsp servers communicating over network ports (local or remote).  Using remote servers over tramp requires installing `emacs-lsp-booster` on the remote server.
+> At present only local or TRAMP-based LSP servers communicating over stdin/stdout can be wrapped—not LSP servers communicating over network ports (local or remote). Using remote servers over TRAMP requires installing `emacs-lsp-booster` on the remote machine.
 
 ## Testing
 
-Maybe you don't even need this.  You can `M-x eglot-booster` to disable the boost at any time.  Then `M-x eglot-shutdown-all`, restart eglot (`M-x eglot` is usually enough) in a large/heavy-weight file, and compare performance before and after.
+You can disable boosting at any time with:
 
-## I/O Only
+```
+M-x eglot-booster
+```
+
+Then run `M-x eglot-shutdown-all`, restart Eglot (`M-x eglot`), and compare performance on a large/heavy file before/after.
+
+## I/O Only Mode
 
 > [!NOTE]
-> Emacs v30 introduced a much faster JSON parser.  [Testing](https://www.reddit.com/r/emacs/comments/1jsxamc/the_new_json_parser_is_fast/) shows that it decodes faster than elisp bytecode, but the I/O takes longer.  So with bytecode disabled, lightweight messages from server->Emacs go a bit slower, and heavy messages go faster.  Definitely worth testing.
+> Emacs v30 introduced a much faster JSON parser. Testing shows it decodes faster than bytecode, while bytecode still gives faster I/O. With bytecode disabled, small messages are slightly slower but large ones are faster. Worth testing for your workflow.
 
-`emacs-lsp-booster` offers the option `--disable-bytecode`.  Setting `eglot-booster-io-only=t` will use this option, processing JSON as normal.  This way you still get the benefit of I/O buffering, but can use Emacs' native JSON parser (which was substantially sped-up in v30).
+`emacs-lsp-booster` provides the flag `--disable-bytecode`.
+Setting:
+
+```elisp
+(setq eglot-booster-io-only t)
+```
+
+or in `use-package`:
+
+```elisp
+(use-package eglot-booster
+  :vc (:url "https://github.com/jdtsmith/eglot-booster")
+  :after eglot
+  :custom
+  (eglot-booster-io-only t)   ;; Enable IO-only mode
+  :config
+  (eglot-booster-mode))
+```
+
+enables IO-only mode. This retains fast buffered I/O while using Emacs 30’s much faster native JSON parser.


### PR DESCRIPTION
- Add use-package example using Emacs’ built-in :vc for installing eglot-booster.
- Add configuration example enabling IO-only mode (eglot-booster-io-only = t).